### PR TITLE
bugfix: MAC_OS never set to 1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ dataset/reads-10000.fastq
 tests/
 scripts/tmp/
 scripts/convert_fasta
+.vscode/
+egsa.dSYM/

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ CWARNING =  -Wall -Wno-implicit-function-declaration -Wno-unused-result
 MY_CXX_OPT_FLAGS= -O3 -m64 -D_FILE_OFFSET_BITS=64
 #-fomit-frame-pointer -ffast-math -funroll-loops 
 
-LFLAGS = -lm -ldl
+LFLAGS = -lm -ldl -g
 
 LIBOBJ =	external/malloc_count/malloc_count.o\
 		external/gsaca-k.o\

--- a/lib/file.c
+++ b/lib/file.c
@@ -3,7 +3,7 @@
 #define BUFFER_SIZE 4098
 
 #ifndef MAC_OS
-  #define MAC_OS 0
+  #define MAC_OS 1
 #endif
 
 /**********************************************************************/


### PR DESCRIPTION
The Macro MAC_OS is never set to 1 in the original code which causes malloc errors. 